### PR TITLE
Add TCP/UDP protocol statistics tool for network health diagnosis

### DIFF
--- a/src/pcp_mcp/icons.py
+++ b/src/pcp_mcp/icons.py
@@ -31,3 +31,4 @@ TAGS_DISK = {"disk", "io", "troubleshooting", "performance"}
 TAGS_NETWORK = {"network", "troubleshooting", "performance"}
 TAGS_DIAGNOSE = {"diagnosis", "troubleshooting", "workflow"}
 TAGS_FILESYSTEM = {"filesystem", "storage", "disk", "capacity"}
+TAGS_NETWORK_STATS = {"network", "tcp", "udp", "protocol", "troubleshooting"}

--- a/src/pcp_mcp/models.py
+++ b/src/pcp_mcp/models.py
@@ -164,6 +164,52 @@ class DiagnosisResult(BaseModel):
     recommendations: list[str] = Field(description="Actionable recommendations")
 
 
+class TCPStats(BaseModel):
+    """TCP protocol statistics."""
+
+    active_opens_per_sec: float = Field(description="Active connections initiated per second")
+    passive_opens_per_sec: float = Field(description="Passive connections accepted per second")
+    attempt_fails_per_sec: float = Field(description="Failed connection attempts per second")
+    estab_resets_per_sec: float = Field(description="Established connections reset per second")
+    current_established: int = Field(description="Currently established connections")
+    retransmits_per_sec: float = Field(description="Segments retransmitted per second")
+    in_errors_per_sec: float = Field(description="Segments received with errors per second")
+    out_resets_per_sec: float = Field(description="RST segments sent per second")
+    assessment: str = Field(description="Brief interpretation of TCP health")
+
+
+class UDPStats(BaseModel):
+    """UDP protocol statistics."""
+
+    in_datagrams_per_sec: float = Field(description="Datagrams received per second")
+    out_datagrams_per_sec: float = Field(description="Datagrams sent per second")
+    in_errors_per_sec: float = Field(description="Receive errors per second")
+    no_ports_per_sec: float = Field(description="Datagrams to unknown ports per second")
+    assessment: str = Field(description="Brief interpretation of UDP health")
+
+
+class InterfaceErrors(BaseModel):
+    """Per-interface error and drop counts."""
+
+    interface: str = Field(description="Network interface name")
+    in_errors_per_sec: float = Field(description="Receive errors per second")
+    out_errors_per_sec: float = Field(description="Transmit errors per second")
+    in_drops_per_sec: float = Field(description="Receive drops per second")
+
+
+class NetworkStatsSnapshot(BaseModel):
+    """TCP/UDP protocol statistics and interface error summary."""
+
+    timestamp: str = Field(description="ISO8601 timestamp")
+    hostname: str = Field(description="Target host name")
+    tcp: TCPStats | None = Field(default=None, description="TCP protocol statistics")
+    udp: UDPStats | None = Field(default=None, description="UDP protocol statistics")
+    interface_errors: list[InterfaceErrors] = Field(
+        default_factory=list, description="Per-interface error/drop rates"
+    )
+    assessment: str = Field(description="Overall network health assessment")
+
+
 class FilesystemInfo(BaseModel):
     """Information about a single mounted filesystem."""
 

--- a/src/pcp_mcp/prompts/network.py
+++ b/src/pcp_mcp/prompts/network.py
@@ -32,11 +32,15 @@ def check_network_performance() -> str:
    - Note: These are COUNTERS, use get_system_snapshot for rates
    - Identify busy interfaces vs idle interfaces (e.g., eth0 busy, lo idle)
 
-4. Check for errors and drops:
-   - Run: query_metrics(["network.interface.in.errors", "network.interface.out.errors"])
-   - Run: query_metrics(["network.interface.in.drops", "network.interface.out.drops"])
-   - Non-zero errors = Hardware, driver, or cable issues
-   - Non-zero drops = Buffer overflow (traffic exceeds processing capacity)
+4. Check for errors, drops, and protocol health:
+   - Run: get_network_stats() for TCP/UDP stats and interface errors in one call
+   - TCP retransmits > 0 = Packet loss or congestion
+   - TCP attempt_fails > 0 = Services unreachable or firewall blocks
+   - TCP estab_resets > 0 = Peers crashing or rejecting connections
+   - TCP current_established = Connection count (high values may indicate leaks)
+   - UDP in_errors > 0 = Receive errors, possible data loss
+   - Interface in_errors/out_errors = Hardware, driver, or cable issues
+   - Interface in_drops = Buffer overflow (traffic exceeds processing capacity)
 
 5. Calculate interface saturation:
    - Compare throughput to link speed (e.g., 950 Mbps on 1 Gbps link = 95%)
@@ -48,10 +52,10 @@ def check_network_performance() -> str:
    - Use system tools: netstat, ss, iftop (outside PCP)
    - Or correlate: High network I/O often correlates with high CPU/disk I/O
 
-7. Check protocol-level stats (if needed):
-   - Run: search_metrics("network.tcp")
-   - Run: search_metrics("network.udp")
-   - Look for: Retransmissions, failed connections, buffer overflows
+7. Drill into specific protocol issues (if needed):
+   - Run: search_metrics("network.tcp") for all available TCP metrics
+   - Run: search_metrics("network.udp") for all available UDP metrics
+   - Use query_metrics() for raw counter values when deeper analysis is needed
 
 8. Report:
    - Per-interface throughput (e.g., "eth0: 850 Mbps in, 120 Mbps out")

--- a/src/pcp_mcp/tools/network.py
+++ b/src/pcp_mcp/tools/network.py
@@ -1,0 +1,183 @@
+"""Network protocol statistics tools for TCP/UDP health analysis."""
+
+from datetime import datetime, timezone
+from typing import Annotated, Optional
+
+from fastmcp import Context
+from fastmcp.tools import tool
+from fastmcp.tools.tool import ToolResult
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from pcp_mcp.context import get_client_for_host
+from pcp_mcp.icons import ICON_NETWORK, TAGS_NETWORK_STATS
+from pcp_mcp.models import NetworkStatsSnapshot
+from pcp_mcp.utils.builders import (
+    build_interface_errors,
+    build_tcp_stats,
+    build_udp_stats,
+)
+
+__all__ = ["get_network_stats"]
+
+TOOL_ANNOTATIONS = ToolAnnotations(readOnlyHint=True, openWorldHint=True)
+
+TCP_METRICS = [
+    "network.tcp.activeopens",
+    "network.tcp.passiveopens",
+    "network.tcp.attemptfails",
+    "network.tcp.estabresets",
+    "network.tcp.currestab",
+    "network.tcp.retranssegs",
+    "network.tcp.inerrs",
+    "network.tcp.outrsts",
+]
+
+UDP_METRICS = [
+    "network.udp.indatagrams",
+    "network.udp.outdatagrams",
+    "network.udp.inerrors",
+    "network.udp.noports",
+]
+
+INTERFACE_ERROR_METRICS = [
+    "network.interface.in.errors",
+    "network.interface.out.errors",
+    "network.interface.in.drops",
+]
+
+# All TCP/UDP metrics are counters except currestab (instant gauge)
+COUNTER_METRICS = {
+    "network.tcp.activeopens",
+    "network.tcp.passiveopens",
+    "network.tcp.attemptfails",
+    "network.tcp.estabresets",
+    "network.tcp.retranssegs",
+    "network.tcp.inerrs",
+    "network.tcp.outrsts",
+    "network.udp.indatagrams",
+    "network.udp.outdatagrams",
+    "network.udp.inerrors",
+    "network.udp.noports",
+    "network.interface.in.errors",
+    "network.interface.out.errors",
+    "network.interface.in.drops",
+}
+
+
+@tool(
+    annotations=TOOL_ANNOTATIONS,
+    icons=[ICON_NETWORK],
+    tags=TAGS_NETWORK_STATS,
+    timeout=30.0,
+)
+async def get_network_stats(
+    ctx: Context,
+    sample_interval: Annotated[
+        float,
+        Field(
+            default=1.0,
+            ge=0.1,
+            le=10.0,
+            description="Seconds between samples for rate calculation",
+        ),
+    ] = 1.0,
+    host: Annotated[
+        Optional[str],
+        Field(description="Target pmcd host to query (default: server's configured target)"),
+    ] = None,
+) -> ToolResult:
+    """Get TCP/UDP protocol statistics and interface error rates.
+
+    Returns protocol-level network health metrics that go deeper than
+    interface throughput. Use this to diagnose connection failures,
+    packet loss, retransmissions, and network errors.
+
+    Key indicators:
+    - TCP retransmits: Packet loss or network congestion
+    - TCP connection failures: Unreachable services or firewall blocks
+    - TCP connection resets: Peers crashing or rejecting connections
+    - TCP current established: Connection count (detect leaks)
+    - UDP errors: Data loss on UDP flows
+    - Interface errors/drops: Hardware, driver, or buffer issues
+
+    Use get_system_snapshot(categories=["network"]) for throughput.
+    Use this tool for protocol health and error diagnosis.
+
+    Examples:
+        get_network_stats() - Full protocol stats on default host
+        get_network_stats(sample_interval=2.0) - Longer sample for accuracy
+        get_network_stats(host="web1.example.com") - Query remote host
+    """
+    from pcp_mcp.errors import handle_pcp_error
+
+    all_metrics = TCP_METRICS + UDP_METRICS + INTERFACE_ERROR_METRICS
+
+    async def report_progress(current: float, total: float, message: str) -> None:
+        await ctx.report_progress(current, total, message)
+
+    async with get_client_for_host(ctx, host) as client:
+        try:
+            data = await client.fetch_with_rates(
+                all_metrics,
+                COUNTER_METRICS,
+                sample_interval,
+                progress_callback=report_progress,
+            )
+        except Exception as e:
+            raise handle_pcp_error(e, "fetching network stats") from e
+
+        await ctx.report_progress(92, 100, "Building network stats...")
+
+        tcp = build_tcp_stats(data)
+        udp = build_udp_stats(data)
+        iface_errors = build_interface_errors(data)
+
+        # Build overall assessment
+        assessment = _assess_network_stats(tcp, udp, iface_errors)
+
+        await ctx.report_progress(100, 100, "Complete")
+
+        result = NetworkStatsSnapshot(
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            hostname=client.target_host,
+            tcp=tcp,
+            udp=udp,
+            interface_errors=iface_errors,
+            assessment=assessment,
+        )
+        return ToolResult(
+            content=result.model_dump_json(),
+            structured_content=result.model_dump(),
+        )
+
+
+def _assess_network_stats(tcp, udp, iface_errors) -> str:
+    """Generate overall network health assessment."""
+    issues = []
+
+    if tcp.retransmits_per_sec > 100:
+        issues.append(f"heavy TCP retransmissions ({tcp.retransmits_per_sec:.0f}/s)")
+    elif tcp.retransmits_per_sec > 10:
+        issues.append(f"moderate TCP retransmissions ({tcp.retransmits_per_sec:.0f}/s)")
+
+    if tcp.attempt_fails_per_sec > 10:
+        issues.append(f"high TCP connection failures ({tcp.attempt_fails_per_sec:.0f}/s)")
+
+    if tcp.estab_resets_per_sec > 10:
+        issues.append(f"frequent TCP resets ({tcp.estab_resets_per_sec:.0f}/s)")
+
+    if udp.in_errors_per_sec > 10:
+        issues.append(f"UDP receive errors ({udp.in_errors_per_sec:.0f}/s)")
+
+    error_ifaces = [
+        ie.interface
+        for ie in iface_errors
+        if ie.in_errors_per_sec > 0 or ie.out_errors_per_sec > 0 or ie.in_drops_per_sec > 0
+    ]
+    if error_ifaces:
+        issues.append(f"interface errors on {', '.join(error_ifaces)}")
+
+    if not issues:
+        return "Network protocol health is normal"
+    return "Issues detected: " + "; ".join(issues)

--- a/tests/test_tools_network.py
+++ b/tests/test_tools_network.py
@@ -1,0 +1,378 @@
+"""Tests for network protocol statistics tools."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call
+
+import httpx
+import pytest
+from fastmcp.exceptions import ToolError
+
+from pcp_mcp.tools.network import _assess_network_stats, get_network_stats
+from pcp_mcp.utils.builders import build_interface_errors, build_tcp_stats, build_udp_stats
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def network_tools() -> dict:
+    """Fixture providing network tools as a dictionary."""
+    return {
+        "get_network_stats": get_network_stats,
+    }
+
+
+@pytest.fixture
+def tcp_metrics_data() -> Callable[..., dict]:
+    """Factory for TCP metrics data with configurable values."""
+
+    def _make(
+        active_opens: float = 5.0,
+        passive_opens: float = 10.0,
+        attempt_fails: float = 0.5,
+        estab_resets: float = 0.2,
+        current_estab: int = 150,
+        retrans: float = 1.0,
+        in_errs: float = 0.0,
+        out_rsts: float = 0.3,
+    ) -> dict:
+        return {
+            "network.tcp.activeopens": {"instances": {-1: active_opens}},
+            "network.tcp.passiveopens": {"instances": {-1: passive_opens}},
+            "network.tcp.attemptfails": {"instances": {-1: attempt_fails}},
+            "network.tcp.estabresets": {"instances": {-1: estab_resets}},
+            "network.tcp.currestab": {"instances": {-1: current_estab}},
+            "network.tcp.retranssegs": {"instances": {-1: retrans}},
+            "network.tcp.inerrs": {"instances": {-1: in_errs}},
+            "network.tcp.outrsts": {"instances": {-1: out_rsts}},
+        }
+
+    return _make
+
+
+@pytest.fixture
+def udp_metrics_data() -> Callable[..., dict]:
+    """Factory for UDP metrics data with configurable values."""
+
+    def _make(
+        in_dgrams: float = 500.0,
+        out_dgrams: float = 300.0,
+        in_errs: float = 0.0,
+        no_ports: float = 2.0,
+    ) -> dict:
+        return {
+            "network.udp.indatagrams": {"instances": {-1: in_dgrams}},
+            "network.udp.outdatagrams": {"instances": {-1: out_dgrams}},
+            "network.udp.inerrors": {"instances": {-1: in_errs}},
+            "network.udp.noports": {"instances": {-1: no_ports}},
+        }
+
+    return _make
+
+
+@pytest.fixture
+def interface_error_metrics_data() -> Callable[..., dict]:
+    """Factory for interface error metrics data with configurable values."""
+
+    def _make(
+        in_errors: dict[str, float] | None = None,
+        out_errors: dict[str, float] | None = None,
+        in_drops: dict[str, float] | None = None,
+    ) -> dict:
+        return {
+            "network.interface.in.errors": {
+                "instances": in_errors or {"eth0": 0.0, "lo": 0.0}
+            },
+            "network.interface.out.errors": {
+                "instances": out_errors or {"eth0": 0.0, "lo": 0.0}
+            },
+            "network.interface.in.drops": {
+                "instances": in_drops or {"eth0": 0.0, "lo": 0.0}
+            },
+        }
+
+    return _make
+
+
+@pytest.fixture
+def full_network_stats_data(
+    tcp_metrics_data,
+    udp_metrics_data,
+    interface_error_metrics_data,
+) -> Callable[..., dict]:
+    """Factory for full network stats data combining TCP, UDP, and interface errors."""
+
+    def _make(**overrides) -> dict:
+        data = {}
+        data.update(tcp_metrics_data())
+        data.update(udp_metrics_data())
+        data.update(interface_error_metrics_data())
+        for key, value in overrides.items():
+            if key in data:
+                data[key] = value
+        return data
+
+    return _make
+
+
+# =============================================================================
+# Tool Tests
+# =============================================================================
+
+
+class TestGetNetworkStats:
+    async def test_returns_all_sections(
+        self,
+        mock_context: MagicMock,
+        network_tools: dict,
+        full_network_stats_data: Callable[..., dict],
+    ) -> None:
+        mock_context.request_context.lifespan_context[
+            "client"
+        ].fetch_with_rates.return_value = full_network_stats_data()
+
+        result = await network_tools["get_network_stats"](mock_context)
+
+        assert result.structured_content["tcp"] is not None
+        assert result.structured_content["udp"] is not None
+        assert result.structured_content["interface_errors"] is not None
+        assert result.structured_content["hostname"] == "localhost"
+        assert result.structured_content["assessment"] is not None
+
+    async def test_tcp_fields_present(
+        self,
+        mock_context: MagicMock,
+        network_tools: dict,
+        full_network_stats_data: Callable[..., dict],
+    ) -> None:
+        mock_context.request_context.lifespan_context[
+            "client"
+        ].fetch_with_rates.return_value = full_network_stats_data()
+
+        result = await network_tools["get_network_stats"](mock_context)
+        tcp = result.structured_content["tcp"]
+
+        assert "active_opens_per_sec" in tcp
+        assert "passive_opens_per_sec" in tcp
+        assert "attempt_fails_per_sec" in tcp
+        assert "estab_resets_per_sec" in tcp
+        assert "current_established" in tcp
+        assert "retransmits_per_sec" in tcp
+        assert "in_errors_per_sec" in tcp
+        assert "out_resets_per_sec" in tcp
+        assert "assessment" in tcp
+
+    async def test_udp_fields_present(
+        self,
+        mock_context: MagicMock,
+        network_tools: dict,
+        full_network_stats_data: Callable[..., dict],
+    ) -> None:
+        mock_context.request_context.lifespan_context[
+            "client"
+        ].fetch_with_rates.return_value = full_network_stats_data()
+
+        result = await network_tools["get_network_stats"](mock_context)
+        udp = result.structured_content["udp"]
+
+        assert "in_datagrams_per_sec" in udp
+        assert "out_datagrams_per_sec" in udp
+        assert "in_errors_per_sec" in udp
+        assert "no_ports_per_sec" in udp
+        assert "assessment" in udp
+
+    async def test_interface_errors_present(
+        self,
+        mock_context: MagicMock,
+        network_tools: dict,
+        full_network_stats_data: Callable[..., dict],
+    ) -> None:
+        mock_context.request_context.lifespan_context[
+            "client"
+        ].fetch_with_rates.return_value = full_network_stats_data()
+
+        result = await network_tools["get_network_stats"](mock_context)
+        iface_errors = result.structured_content["interface_errors"]
+
+        assert len(iface_errors) == 2
+        assert iface_errors[0]["interface"] in ("eth0", "lo")
+
+    async def test_reports_progress(
+        self,
+        mock_context: MagicMock,
+        network_tools: dict,
+        full_network_stats_data: Callable[..., dict],
+    ) -> None:
+        mock_context.request_context.lifespan_context[
+            "client"
+        ].fetch_with_rates.return_value = full_network_stats_data()
+        mock_context.report_progress = AsyncMock()
+
+        await network_tools["get_network_stats"](mock_context)
+
+        assert mock_context.report_progress.call_count >= 2
+        calls = mock_context.report_progress.call_args_list
+        assert calls[-1] == call(100, 100, "Complete")
+
+    async def test_handles_connection_error(
+        self,
+        mock_context: MagicMock,
+        network_tools: dict,
+    ) -> None:
+        mock_context.request_context.lifespan_context[
+            "client"
+        ].fetch_with_rates.side_effect = httpx.ConnectError("Connection refused")
+
+        with pytest.raises(ToolError, match="Cannot connect to pmproxy"):
+            await network_tools["get_network_stats"](mock_context)
+
+
+# =============================================================================
+# Builder Tests
+# =============================================================================
+
+
+class TestBuildTcpStats:
+    def test_builds_from_normal_data(self, tcp_metrics_data) -> None:
+        result = build_tcp_stats(tcp_metrics_data())
+
+        assert result.active_opens_per_sec == 5.0
+        assert result.passive_opens_per_sec == 10.0
+        assert result.current_established == 150
+        assert result.retransmits_per_sec == 1.0
+        assert "normal" in result.assessment.lower()
+
+    @pytest.mark.parametrize(
+        ("retrans", "expected_keyword"),
+        [
+            (150.0, "heavy"),
+            (15.0, "moderate"),
+            (0.0, "normal"),
+        ],
+    )
+    def test_retransmit_assessment(
+        self, tcp_metrics_data, retrans: float, expected_keyword: str
+    ) -> None:
+        result = build_tcp_stats(tcp_metrics_data(retrans=retrans))
+        assert expected_keyword.lower() in result.assessment.lower()
+
+    def test_high_attempt_fails(self, tcp_metrics_data) -> None:
+        result = build_tcp_stats(tcp_metrics_data(attempt_fails=20.0))
+        assert "failure" in result.assessment.lower()
+
+    def test_high_estab_resets(self, tcp_metrics_data) -> None:
+        result = build_tcp_stats(tcp_metrics_data(estab_resets=15.0))
+        assert "reset" in result.assessment.lower()
+
+    def test_in_errors(self, tcp_metrics_data) -> None:
+        result = build_tcp_stats(tcp_metrics_data(in_errs=5.0))
+        assert "malformed" in result.assessment.lower()
+
+
+class TestBuildUdpStats:
+    def test_builds_from_normal_data(self, udp_metrics_data) -> None:
+        result = build_udp_stats(udp_metrics_data())
+
+        assert result.in_datagrams_per_sec == 500.0
+        assert result.out_datagrams_per_sec == 300.0
+        assert result.in_errors_per_sec == 0.0
+        assert "normal" in result.assessment.lower()
+
+    def test_high_in_errors(self, udp_metrics_data) -> None:
+        result = build_udp_stats(udp_metrics_data(in_errs=20.0))
+        assert "error" in result.assessment.lower()
+
+    def test_high_no_ports(self, udp_metrics_data) -> None:
+        result = build_udp_stats(udp_metrics_data(no_ports=200.0))
+        assert "closed ports" in result.assessment.lower()
+
+    def test_some_errors(self, udp_metrics_data) -> None:
+        result = build_udp_stats(udp_metrics_data(in_errs=3.0))
+        assert "some" in result.assessment.lower()
+
+
+class TestBuildInterfaceErrors:
+    def test_builds_from_normal_data(self, interface_error_metrics_data) -> None:
+        result = build_interface_errors(interface_error_metrics_data())
+
+        assert len(result) == 2
+        iface_names = [ie.interface for ie in result]
+        assert "eth0" in iface_names
+        assert "lo" in iface_names
+
+    def test_sorted_by_interface_name(self, interface_error_metrics_data) -> None:
+        result = build_interface_errors(interface_error_metrics_data())
+        names = [ie.interface for ie in result]
+        assert names == sorted(names)
+
+    def test_captures_error_values(self, interface_error_metrics_data) -> None:
+        data = interface_error_metrics_data(
+            in_errors={"eth0": 5.0, "lo": 0.0},
+            out_errors={"eth0": 2.0, "lo": 0.0},
+            in_drops={"eth0": 1.0, "lo": 0.0},
+        )
+        result = build_interface_errors(data)
+
+        eth0 = next(ie for ie in result if ie.interface == "eth0")
+        assert eth0.in_errors_per_sec == 5.0
+        assert eth0.out_errors_per_sec == 2.0
+        assert eth0.in_drops_per_sec == 1.0
+
+    def test_handles_empty_data(self) -> None:
+        data = {
+            "network.interface.in.errors": {"instances": {}},
+            "network.interface.out.errors": {"instances": {}},
+            "network.interface.in.drops": {"instances": {}},
+        }
+        result = build_interface_errors(data)
+        assert result == []
+
+
+# =============================================================================
+# Assessment Tests
+# =============================================================================
+
+
+class TestAssessNetworkStats:
+    def test_healthy_assessment(self, tcp_metrics_data, udp_metrics_data) -> None:
+        tcp = build_tcp_stats(tcp_metrics_data())
+        udp = build_udp_stats(udp_metrics_data())
+        iface_errors = []
+
+        result = _assess_network_stats(tcp, udp, iface_errors)
+        assert "normal" in result.lower()
+
+    def test_retransmit_issue(self, tcp_metrics_data, udp_metrics_data) -> None:
+        tcp = build_tcp_stats(tcp_metrics_data(retrans=50.0))
+        udp = build_udp_stats(udp_metrics_data())
+        iface_errors = []
+
+        result = _assess_network_stats(tcp, udp, iface_errors)
+        assert "retransmission" in result.lower()
+
+    def test_interface_error_issue(
+        self, tcp_metrics_data, udp_metrics_data, interface_error_metrics_data
+    ) -> None:
+        tcp = build_tcp_stats(tcp_metrics_data())
+        udp = build_udp_stats(udp_metrics_data())
+        iface_errors = build_interface_errors(
+            interface_error_metrics_data(in_errors={"eth0": 5.0, "lo": 0.0})
+        )
+
+        result = _assess_network_stats(tcp, udp, iface_errors)
+        assert "eth0" in result
+
+    def test_multiple_issues(self, tcp_metrics_data, udp_metrics_data) -> None:
+        tcp = build_tcp_stats(tcp_metrics_data(retrans=200.0, attempt_fails=20.0))
+        udp = build_udp_stats(udp_metrics_data(in_errs=15.0))
+        iface_errors = []
+
+        result = _assess_network_stats(tcp, udp, iface_errors)
+        assert "retransmission" in result.lower()
+        assert "failure" in result.lower()
+        assert "udp" in result.lower()


### PR DESCRIPTION
## Summary
Adds a new `get_network_stats()` tool that provides protocol-level network health metrics, complementing the existing interface throughput metrics. This enables deeper diagnosis of connection failures, packet loss, retransmissions, and network errors at the TCP/UDP layer.

## Key Changes

- **New tool: `get_network_stats()`** (`src/pcp_mcp/tools/network.py`)
  - Fetches TCP/UDP protocol statistics and per-interface error rates in a single call
  - Returns structured `NetworkStatsSnapshot` with TCP stats, UDP stats, interface errors, and overall assessment
  - Supports configurable sample intervals and remote host targeting
  - Includes progress reporting during metric collection

- **New data models** (`src/pcp_mcp/models.py`)
  - `TCPStats`: Active/passive opens, connection failures, resets, retransmissions, errors
  - `UDPStats`: Datagram rates, receive errors, closed port hits
  - `InterfaceErrors`: Per-interface error and drop rates
  - `NetworkStatsSnapshot`: Complete network health snapshot with timestamp and hostname

- **Builder functions** (`src/pcp_mcp/utils/builders.py`)
  - `build_tcp_stats()`: Constructs TCP metrics with health assessment
  - `build_udp_stats()`: Constructs UDP metrics with health assessment
  - `build_interface_errors()`: Extracts per-interface error/drop rates

- **Updated network diagnostics prompt** (`src/pcp_mcp/prompts/network.py`)
  - Recommends using `get_network_stats()` for protocol-level analysis
  - Clarifies interpretation of TCP retransmits, connection failures, and resets
  - Distinguishes between throughput diagnosis (use `get_system_snapshot()`) and protocol health (use `get_network_stats()`)

- **Comprehensive test suite** (`tests/test_tools_network.py`)
  - Tests for tool execution, progress reporting, and error handling
  - Builder function tests with parametrized assessments
  - Assessment logic tests covering healthy and problematic scenarios

## Implementation Details

- Metrics are fetched with rate calculation for counters (TCP/UDP operations, interface errors)
- `network.tcp.currestab` is treated as an instant gauge (connection count)
- Assessment logic uses thresholds to identify issues:
  - TCP retransmits > 100/s: heavy, > 10/s: moderate
  - TCP attempt fails > 10/s: high failure rate
  - TCP resets > 10/s: frequent connection resets
  - UDP errors > 10/s: high error rate
  - Any interface with errors/drops is flagged
- Results include both raw metrics and human-readable assessments for quick diagnosis

https://claude.ai/code/session_01C7SvcRnVS73kVA6Q2H9GtS